### PR TITLE
Allow "type exists" HEAD queries.

### DIFF
--- a/config/jetty-restrict-writes.xml
+++ b/config/jetty-restrict-writes.xml
@@ -217,7 +217,7 @@
                     <New class="org.eclipse.jetty.security.ConstraintMapping">
                         <Set name="method">HEAD</Set>
                         <Set name="pathSpec">
-                            /{index}/{type}/{id}
+                            /{index}/{type},/{index}/{type}/{id}
                         </Set>
                         <Set name="constraint">
                             <Ref id="ReadOnlyUserDataSecurityConstraint"/>


### PR DESCRIPTION
Hello and thanks for the fork,
We wanted to expose the "type exists" HEAD queries.  I thought that because the feature was committed to elasticsearch in Sept 2012, and the last change to the elasticsearch-jetty restrict-writes config file was in July 2012 that it is query that would have been allowed.
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-types-exists.html
Added in:
  https://github.com/elastic/elasticsearch/issues/2273
Thanks
